### PR TITLE
Refactor uid of models to return str(id) instead

### DIFF
--- a/alexis/components/database.py
+++ b/alexis/components/database.py
@@ -144,7 +144,7 @@ class BaseModel(Base, ModelErrorMixin):  # type: ignore[valid-type, misc]
     @property
     def uid(self):
         """Return the UUID of the model as a string."""
-        return self.id.hex
+        return str(self.id)
 
     def __repr__(self):
         """Return a string representation of the model."""


### PR DESCRIPTION
This pull request refactors the uid method of models to return the string representation of the id instead of the hex representation. This change ensures consistency and improves readability in the codebase.