### PR TITLE
Refactor preprocess_project function

### DIFF
--- a/alexis/components/contexts.py
+++ b/alexis/components/contexts.py
@@ -363,13 +363,13 @@ async def summarize_project_description(description: str) -> str:
     return await ProjectSummaryChain.ainvoke(description)
 
 
-async def preprocess_project(project: ProjectDump) -> ProjectDump:
+async def preprocess_project(project: Project):
     """Preprocess project description to minimize cost."""
     from alexis.tools.preprocessors import ProjectDescriptionPreprocessor
 
-    description: str = project["description"]
+    description: str = project.description
     preprocessor = ProjectDescriptionPreprocessor(description)
-    logging.info(f"Preprocessing project '{project['id']}' description...")
+    logging.info(f"Preprocessing project '{project.id}'")
     logging.info(f"Token count (before): {count_tokens(description)}")
     preprocessed = preprocessor.preprocess()
     token_count = count_tokens(preprocessed)
@@ -378,8 +378,8 @@ async def preprocess_project(project: ProjectDump) -> ProjectDump:
         logging.info("Project description too long. Summarizing...")
         preprocessed = await summarize_project_description(description)
         logging.info(f"Token count (after): {count_tokens(preprocessed)}")
-    project["description"] = preprocessed
-    return project
+    project.description = preprocessed
+    project.save()
 
 
 __all__ = [

--- a/alexis/components/database.py
+++ b/alexis/components/database.py
@@ -130,6 +130,8 @@ class BaseDocument(Document, DocumentErrorMixin, metaclass=DocumentMetaClass):
     """Base document for MongoDB."""
 
     meta = BaseDocumentMeta | {"abstract": True}
+    DoesNotExist: ClassVar[type[Exception]]
+    """Document does not exist error."""
 
     id: UUID = UUIDField(primary_key=True, default=uuid4)
     created_at: datetime = DateTimeField(default=utcnow)

--- a/alexis/sentry.py
+++ b/alexis/sentry.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from dynaconf import Dynaconf  # type: ignore[import]
 
 
-def get_centry_integration(config: "Dynaconf"):
+def get_sentry_integrations(config: "Dynaconf"):
     """Get Sentry integrations."""
     for _logger in config.SENTRY_IGNORED_LOGGERS:
         ignore_logger(_logger)
@@ -55,7 +55,7 @@ def setup_sentry(config: "Dynaconf"):
         return
     sentry_sdk.init(
         dsn=config.SENTRY_DSN,
-        integrations=get_centry_integration(config),
+        integrations=get_sentry_integrations(config),
         traces_sample_rate=config.SENTRY_TRACES_SAMPLE_RATE,
         profiles_sample_rate=config.SENTRY_PROFILES_SAMPLE_RATE,
         environment=config.current_env,


### PR DESCRIPTION
This pull request refactors the preprocess_project function to take in a project object instead of a ProjectDump object. It also updates the function to use type hints and fixes a typo in the code.